### PR TITLE
Lab0-Exercise 1-Remove phone number entry since it´s not appearing in maker portal

### DIFF
--- a/Instructions/Labs/LAB[PL-200]_M00L00_Validate_Lab_Environment.md
+++ b/Instructions/Labs/LAB[PL-200]_M00L00_Validate_Lab_Environment.md
@@ -40,7 +40,7 @@ In this exercise, you will verify that you can access Power Apps.
 
 1.  Optionally, select **Yes** to stay signed in.
 
-1.  If prompted for contact information, leave the Country/region as the default value and enter `0123456789` for Phone number and select **Submit**.
+1.  If prompted for contact information, leave the Country/region as the default value and  select **Get started**.
 
 1.  **Refresh** the page.
 


### PR DESCRIPTION
## Summary

Updated the lab instructions to align with the current Power Apps Maker portal UI by removing the phone number entry step and reflecting the updated **Get started** action.

## Changes

- Removed the instruction to enter a phone number, which no longer appears in the current Maker portal experience.
- Updated the step to select **Get started** to match the latest UI behavior.

## Reason for Change

The existing instructions referenced a phone number field that is no longer displayed in the Maker portal. This update ensures learners can follow the lab without confusion and complete the step successfully using the current UI.

## Impact

- Improves accuracy of lab instructions.
- Prevents learner blockers caused by outdated UI steps.