### PR TITLE
Lab1.2-Removed the Phone number step because it no longer reflects in maker portal

### DIFF
--- a/Instructions/Labs/LAB[PL-200]_M01L02_Solution.md
+++ b/Instructions/Labs/LAB[PL-200]_M01L02_Solution.md
@@ -20,8 +20,6 @@ In this exercise, you will access the Power Apps maker portal, the Developer env
 
 1.  In a new tab, navigate to the Power Apps Maker portal `https://make.powerapps.com` and sign in with your Microsoft 365 credentials if prompted again.
 
-1.  If you are prompted for a **Phone number** enter `0123456789` and select **Submit**.
-
 1.  Switch environments by using the Environment Selector in the upper right corner of the screen.
 
 1.  Select the **Dev One** environment from the list.


### PR DESCRIPTION
## Summary

Updated the lab instructions to remove the phone number prompt, aligning the steps with the current Power Apps Maker portal experience.

## Changes

- Removed the instruction to enter a **Phone number**, which is no longer requested in the Maker portal.
- Kept the remaining steps unchanged to preserve the intended lab flow.

## Reason for Change

The Maker portal no longer prompts users to provide a phone number during sign-in. Keeping this step caused confusion and did not reflect the current UI. This update ensures the instructions are accurate and easy to follow.

## Impact

- Improves accuracy of lab instructions.
- Prevents learner confusion caused by outdated UI references.
