### PR TITLE
Lab2.1-Add note to export solution steps for classic experience workaround

### DIFF
--- a/Instructions/Labs/LAB[PL-200]_M02L01_Security_roles.md
+++ b/Instructions/Labs/LAB[PL-200]_M02L01_Security_roles.md
@@ -211,6 +211,7 @@ In this exercise, you will export the solution from the Development environment 
 1. Select **Managed** for **Export as**.
 
 1. Select **Export**.
+> NOTE: If the export process remains stuck on **Currently exporting solution** and does not complete, select Switch to classic from the command bar and export the solution using the classic experience instead
 
 1. The export will be prepared in the background, when the solution is ready select the **Download** button.
 


### PR DESCRIPTION
## Summary

Added a note to the solution export tasks to document a workaround when the export process becomes stuck on **Currently exporting solution**.

In some environments, exporting a solution from the modern experience may not complete successfully. This update guides learners to use the **Switch to classic** option to complete the export when this issue occurs.

---

## Changes Included

- Added a **note** to **Task 2.1 – Export managed solution** explaining how to proceed if the export gets stuck
