### PR TITLE
Lab3.1- update lab steps to use Save and publish to match current UI

### DIFF
--- a/Instructions/Labs/LAB[PL-200]_M03L01_Forms.md
+++ b/Instructions/Labs/LAB[PL-200]_M03L01_Forms.md
@@ -789,9 +789,7 @@ In this task, you will perform the following changes to the app:
 
     ![App designer.](../media/app-designer.png)
 
-1. Select **Save**.
-
-1. Select **Publish**.
+1. Select **Save and publish**.
 
 1. Select **Play**.
 
@@ -824,9 +822,7 @@ In this task, you will perform the following changes to the app:
 
 1. In the **Outcomes forms** pane on the right side, select the ellipsis **...** menu on the **Manager** form and select **Remove**.
 
-1. Select **Save**.
-
-1. Select **Publish**.
+1. Select **Save and publish**.
 
 1. Select **Play**.
 


### PR DESCRIPTION
## Description

This PR updates the lab instructions to reflect the current Power Apps designer UI.

The previous steps instructed learners to select **Save** and then **Publish** as separate actions. In the current UI, these actions are combined into a single **Save and publish** command. This change ensures the lab accurately matches what learners see in the product and avoids confusion.

## Changes included

- Updated lab steps to replace separate **Save** and **Publish** actions with **Save and publish**
- Aligned instructions with the current Power Apps command bar UI