### PR TITLE
Lab3.3- Add the step **Select Done** to reflect UI completion

### DIFF
--- a/Instructions/Labs/LAB[PL-200]_M03L03_Command.md
+++ b/Instructions/Labs/LAB[PL-200]_M03L03_Command.md
@@ -79,3 +79,5 @@ In this task, you will perform the following changes to the Project Outcome form
 1.  In the **Environmental Project Delivery** app, select **Save and publish.**
 
 1. **Close** the app designer.
+
+1. Select **Done**.


### PR DESCRIPTION
## Description

This PR adds a missing **Select Done** step after closing the app designer to ensure the lab instructions fully reflect the current UI completion flow.

Previously, the lab concluded after closing the app designer, but the UI requires selecting **Done** to explicitly complete the task.

## Change details

- Added **Select Done** step after closing the app designer
