### PR TITLE
Lab4.1-Remove Maker Studio references and align app creation steps with Power Apps Maker portal UI

### DIFF
--- a/Instructions/Labs/LAB[PL-200]_M04L01_Canvas.md
+++ b/Instructions/Labs/LAB[PL-200]_M04L01_Canvas.md
@@ -14,9 +14,9 @@ This lab will take approximately **30** minutes to complete.
 ## Exercise 1: Create Canvas App from Milestones Table
 
 ### Task 1: Create Canvas App
-1. Navigate to [Power Apps Maker Portal](https://make.powerapps.com).
+1. Navigate to the Power Apps Maker portal `https://make.powerapps.com`
 2. Ensure you are in the **Dev One** environment.
-3. In the Maker Studio, select **Apps.**
+3. Select **Apps.**.
 4. Select **Start with data**.
 5. Choose **Select existing tables.**
 6. Search for and select the **Milestone** table.

--- a/Instructions/Labs/LAB[PL-200]_M04L01_Canvas.md
+++ b/Instructions/Labs/LAB[PL-200]_M04L01_Canvas.md
@@ -21,9 +21,10 @@ This lab will take approximately **30** minutes to complete.
 5. Choose **Select existing tables.**
 6. Search for and select the **Milestone** table.
 7. Click **Create app** to generate the app.
-8. Select **Save.**
-9. Enter the name **Environmental Milestones App**.
-10. Click **Save** again.
+8. If the **Welcome to Power Apps Studio** dialog appears, select **Skip**.
+9. Select **Save.**
+10. Enter the name **Environmental Milestones App**.
+11. Click **Save** again.
 
 ### Task 2: Configure Gallery
 1. Expand **ScreenContainer1**.


### PR DESCRIPTION
### Summary
This PR updates the canvas app creation steps to align with the current **Power Apps Maker portal** experience and removes incorrect references to **Maker Studio**.

### Changes
- Updated the navigation step to explicitly reference the **Power Apps Maker portal** (`https://make.powerapps.com`) and keep consistency with the other labs.
- Removed the incorrect phrase **“In the Maker Studio”**
- Simplified the step to directly instruct users to select **Apps**
-  Added a conditional step to handle the **Welcome to Power Apps Studio** dialog by selecting **Skip**
- Preserved the existing app creation flow and functionality

### Conclusion
Maker Studio” is not an official Power Apps UI or product name and can be misleading for learners. The updated wording accurately reflects the current Power Apps Maker portal UI and improves consistency with Microsoft Learn terminology and other Power Platform labs.
