### PR TITLE
Lab5.1- Clarify site title field when entering Fabrikam Environmental

### DIFF
--- a/Instructions/Labs/LAB[PL-200]_M05L01_Pages.md
+++ b/Instructions/Labs/LAB[PL-200]_M05L01_Pages.md
@@ -189,7 +189,7 @@ In this exercise, you will explore a Power Pages site and the Power Pages tools.
 
 1. Select **Company name** at the top of the page and select **Edit site header**.
 
-1. Enter **Fabrikam Environmental**.
+1. Enter **Fabrikam Environmental** for **Site title**.
 
     ![Power Pages portal edits.](../media/designer-edit.png)
 

--- a/Instructions/Labs/LAB[PL-200]_M05L01_Pages.md
+++ b/Instructions/Labs/LAB[PL-200]_M05L01_Pages.md
@@ -293,7 +293,7 @@ In this exercise, you will add a list of Milestone rows to the page, add a form 
 
 ### Task 3.3 - Form
 
-1. In the **Pages** pane on the left side, and select **Pages**.
+1. In the **Pages** pane on the left side, select **Pages**.
 
 1. Select the ellipsis (...) and select **Add a new subpage**.
 


### PR DESCRIPTION
### Summary

This PR clarifies the instruction for entering the site name by explicitly specifying the **Site title** field.

### Changes

- Updated the instruction to indicate that **Fabrikam Environmental** should be entered in the **Site title** field.
- Improves clarity and removes ambiguity about where the value should be entered.
-  Fixed grammar in the Pages pane instruction by removing an unnecessary conjunction.