### PR TITLE
Rewrite Bulk delete data lab steps to align with the current UI

### DIFF
--- a/Instructions/Labs/LAB[PL-200]_M99OPT_Bulk_Delete.md
+++ b/Instructions/Labs/LAB[PL-200]_M99OPT_Bulk_Delete.md
@@ -32,39 +32,35 @@ In this exercise, you will create a bulk deletion operation that will delete all
 
 1. Select **Bulk deletion**.
 
-1. Select **New**.
+1. Select **+ New Job**.
 
-1. Select **Next**.
+1. Select **Milestones** from the **Look for entity** drop-down.
 
-1. Select **Milestones** from the **Look for** drop-down.
+1. Select **Estimated Completion Date** for **Field**.
 
-1. Click **Select** and choose the **Estimated Completion Date** column.
+1. Select **Older than X Months** for **Operator**.
 
-1. Select **Older than X Months**.
+1. Enter **12** for **Value**.
 
-1. Enter **12**.
+1. Select **+ Add** drop-down.
 
-1. Click **Select** and choose the **Milestone Status** column.
+1. Select **Add row**.
 
-1. Select **Equals**.
+1. Select **Milestone Status** column for **Field**.
 
-1. Select the ellipsis (...), select **Completed** and **Cancelled**, and select **OK**.
+1. Select **Equals** for **Operator**.
 
-1. Select **Next**.
+1. Select the **Value** drop-down, and then select **Completed** and **Cancelled**.
 
-1. Enter `Delete Old Milestones` for **Name**.
+1. Enter `Delete Old Milestones` for **Job name**.
 
-1. Select **At Scheduled Time**.
+1. Select today’s date and select **9:00 PM** for **Select time**.
 
-1. Select today’s date for **Date** and select **9:00 PM** for **Time**.
-
-1. Check the **Run this job after every** box.
+1. Check the **Run job after every** checkbox.
 
 1. Select **30 days**.
 
-1. Select **Next**.
-
-1. Select **Submit**.
+1. Select **Save and close**.
 
 1. Change the view to **Recurring Bulk Deletion System Jobs**.
 


### PR DESCRIPTION
### Summary
This PR updates the **Bulk delete data** lab instructions to ensure they accurately reflect the current Power Apps UI.

### Changes
- The entry point is now labelled **New Job** instead of **New**.
- Filter criteria are now configured inline (field → operator → value rows) rather than through a multi-step wizard with a separate **Select** picker and ellipsis menu.
- The **Add row** button replaces the previous column-picker flow for adding filter conditions.
- Scheduling fields (date and time) are now combined in a single step rather than split across two steps.
- The final action is now **Save and close** instead of the two-step **Next** → **Submit** flow.
- Field labels updated: **Name** → **Job name**, **Run this job after every** box → **Run job after every** checkbox.
### Reason
Several instructions no longer reflected the current UI labels, control types, or interaction flow, which could confuse learners. These updates improve instructional accuracy, consistency, and alignment with the current experience.
